### PR TITLE
Custom token_path fixes

### DIFF
--- a/questrade_api/__init__.py
+++ b/questrade_api/__init__.py
@@ -1,2 +1,2 @@
-from .questrade import Questrade
-from .auth import Auth
+from .questrade import Questrade  # noqa
+from .auth import Auth  # noqa

--- a/questrade_api/auth.py
+++ b/questrade_api/auth.py
@@ -21,14 +21,14 @@ class Auth:
 
     def __read_token(self):
         try:
-            with open(os.path.expanduser(self.token_path)) as f:
+            with open(self.token_path) as f:
                 str = f.read()
                 return json.loads(str)
         except IOError:
             raise('No token provided and none found at {}'.format(TOKEN_PATH))
 
     def __write_token(self, token):
-        with open(os.path.expanduser(self.token_path), 'w') as f:
+        with open(self.token_path, 'w') as f:
             json.dump(token, f)
 
     def __refresh_token(self, token):

--- a/questrade_api/auth.py
+++ b/questrade_api/auth.py
@@ -30,6 +30,7 @@ class Auth:
     def __write_token(self, token):
         with open(self.token_path, 'w') as f:
             json.dump(token, f)
+        os.chmod(self.token_path, 0o600)
 
     def __refresh_token(self, token):
         req_time = int(time.time())

--- a/questrade_api/questrade.py
+++ b/questrade_api/questrade.py
@@ -15,14 +15,11 @@ class Questrade:
             self.config = self.__read_config(kwargs['config'])
         else:
             self.config = self.__read_config(CONFIG_PATH)
-        if 'refresh_token' in kwargs:
-            self.auth = Auth(
-                refresh_token=kwargs['refresh_token'], token_path=kwargs['token_path'], config=self.config)
-        elif 'token_path' in kwargs:
-            self.auth = Auth(
-                token_path=kwargs['token_path'], config=self.config)
-        else:
-            self.auth = Auth(config=self.config)
+
+        auth_kwargs = {x: y for x, y in kwargs.items() if x in
+                       ['token_path', 'refresh_token']}
+
+        self.auth = Auth(**auth_kwargs, config=self.config)
 
     def __read_config(self, fpath):
         config = configparser.ConfigParser()

--- a/questrade_api/questrade.py
+++ b/questrade_api/questrade.py
@@ -1,6 +1,6 @@
 import os
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import configparser
 import urllib
 from questrade_api.auth import Auth
@@ -17,7 +17,7 @@ class Questrade:
             self.config = self.__read_config(CONFIG_PATH)
         if 'refresh_token' in kwargs:
             self.auth = Auth(
-                refresh_token=kwargs['refresh_token'], config=self.config)
+                refresh_token=kwargs['refresh_token'], token_path=kwargs['token_path'], config=self.config)
         elif 'token_path' in kwargs:
             self.auth = Auth(
                 token_path=kwargs['token_path'], config=self.config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160


### PR DESCRIPTION
- The token_path must be passed to refresh_token call otherwise it's written to ~/.questrade.json instead of the custom token_path.
- A couple fixes for flake8; I set the max line length to 160 (my personal preference)...
- Also, the token file should be read/write only by the current user.